### PR TITLE
Added daily SOFR rate from NY Federal Reserve

### DIFF
--- a/fetch-oracle-data.sh
+++ b/fetch-oracle-data.sh
@@ -12,6 +12,8 @@ ERGO_POOL_ERG_USD_JSON=$(curl -s "https://erg-usd-ergo-oracle.emurgo.io/frontend
 MARKET_STACK_JSON=$(curl -s "http://api.marketstack.com/v1/intraday/latest?access_key=???&symbols=TSLA");
 BTC_TREZOR_JSON=$(curl -s "https://btc1.trezor.io/api/v2")
 
+SOFR_JSON=$(curl -s 'https://markets.newyorkfed.org/api/rates/secured/sofr/last/1.json')
+
 DRAND=$(curl -s "https://api.drand.sh/public/latest" | jq 'del(.signature)' | jq 'del(.previous_signature)')
 
 echo "{"
@@ -90,6 +92,12 @@ echo "    \"TSLA\": ["
 echo "       {"
 echo "         \"value\": \"$(jq '.data[].last' <<< "$MARKET_STACK_JSON")\","
 echo "         \"source\": \"investorsExchange\""
+echo "       }"
+echo "    ],"
+echo "    \"SOFR\": ["
+echo "       {"
+echo "         \"value\": \"$(jq '.refRates[].percentRate' <<< "$SOFR_JSON")\","
+echo "         \"source\": \"newYorkFed\""
 echo "       }"
 echo "    ],"
 echo "    \"DRAND\": $DRAND"


### PR DESCRIPTION
Each business day the US Federal Reserve Bank of New York posts its Secured Overnight Financing Rate (SOFR) [1] via a JSON API [2]. That interbank overnight interest rate is a basis for many other rates and contracts in the US and globally [3].

This pull request adds that rate to the transaction metadata of the Cardano Oracle Publisher. The SOFR data point has the same format as the other data points in this oracle:

        "SOFR": [
           {
             "value": "0.01",
             "source": "newYorkFed"
           }
        ]

The inclusion of this data point to the metadata will increase its cost by approximately 1585 Lovelace per transaction, or 0.58 ADA annually. It will enable smart contracts to reference the SOFR rate. This will be useful in contracts involving futures, options, and stablecoin interest.

References:
1.  [NY Fed SOFR Rate](https://www.newyorkfed.org/markets/reference-rates/sofr)
2.  [NY Fed API Documentation](https://apps.newyorkfed.org/~/media/XML/Schemas/api_spec)
3. [SOFR on Wikipedia](https://en.wikipedia.org/wiki/SOFR)